### PR TITLE
fix: HelloWorldDeployer script

### DIFF
--- a/contracts/script/HelloWorldDeployer.s.sol
+++ b/contracts/script/HelloWorldDeployer.s.sol
@@ -228,7 +228,7 @@ contract HelloWorldDeployer is Script, Utils {
                 address(stakeRegistryImplementation),
                 abi.encodeWithSelector(
                     ECDSAStakeRegistry.initialize.selector,
-                    address(helloWorldServiceManagerImplementation),
+                    address(helloWorldServiceManagerProxy),
                     1,
                     quorum
                 )


### PR DESCRIPTION
Commit https://github.com/Layr-Labs/hello-world-avs/commit/15574f22182027b0e3822e729367bcae291d1f40 introduced a bug: variable `helloWorldServiceManager` was wrongly renamed to `helloWorldServiceManagerImplementation` instead of `helloWorldServiceManagerProxy` at line 231.

This resulted in a dysfunctional deployment when deploying the contracts to a new Anvil environment.

This PR fixes the issue.