### PR TITLE
fix: block number check

### DIFF
--- a/operator/createNewTasks.ts
+++ b/operator/createNewTasks.ts
@@ -23,7 +23,7 @@ function generateRandomName(): string {
     const nouns = ['Fox', 'Dog', 'Cat', 'Mouse', 'Bear'];
     const adjective = adjectives[Math.floor(Math.random() * adjectives.length)];
     const noun = nouns[Math.floor(Math.random() * nouns.length)];
-    const randomName = `${adjective}${noun}${Math.floor(Math.random() * 24000)}`;
+    const randomName = `${adjective}${noun}${Math.floor(Math.random() * 1000)}`;
     return randomName;
   }
 
@@ -47,7 +47,7 @@ function startCreatingTasks() {
     const randomName = generateRandomName();
     console.log(`Creating new task with name: ${randomName}`);
     createNewTask(randomName);
-  }, 5000);
+  }, 24000);
 }
 
 // Start the process

--- a/operator/createNewTasks.ts
+++ b/operator/createNewTasks.ts
@@ -23,7 +23,7 @@ function generateRandomName(): string {
     const nouns = ['Fox', 'Dog', 'Cat', 'Mouse', 'Bear'];
     const adjective = adjectives[Math.floor(Math.random() * adjectives.length)];
     const noun = nouns[Math.floor(Math.random() * nouns.length)];
-    const randomName = `${adjective}${noun}${Math.floor(Math.random() * 1000)}`;
+    const randomName = `${adjective}${noun}${Math.floor(Math.random() * 24000)}`;
     return randomName;
   }
 

--- a/operator/index.ts
+++ b/operator/index.ts
@@ -52,7 +52,7 @@ const signAndRespondToTask = async (taskIndex: number, taskCreatedBlock: number,
     const signatures = [signature];
     const signedTask = ethers.AbiCoder.defaultAbiCoder().encode(
         ["address[]", "bytes[]", "uint32"],
-        [operators, signatures, ethers.toBigInt(await provider.getBlockNumber())]
+        [operators, signatures, ethers.toBigInt(await provider.getBlockNumber()-1)]
     );
 
     const tx = await helloWorldServiceManager.respondToTask(


### PR DESCRIPTION
PR: Adds a delay for task creation, so we don't need to handle a nonce logic for the operator submitting task responses when there are multiple responses in the same block.  We prevent there from being multiple tasks that can be responded to in the same block with a hacky fix of requesting tasks more slowly

this issue wasn't observed in anvil testing because of the automating of blocks afaict