### PR TITLE
chore: fix typo in `DeployEigenLayerCore.s.sol`

### DIFF
--- a/contracts/script/DeployEigenLayerCore.s.sol
+++ b/contracts/script/DeployEigenLayerCore.s.sol
@@ -6,7 +6,7 @@ import {Script} from "forge-std/Script.sol";
 import {CoreDeploymentLib} from "./utils/CoreDeploymentLib.sol";
 import {UpgradeableProxyLib} from "./utils/UpgradeableProxyLib.sol";
 
-contract DeployEigenlayerCore is Script {
+contract DeployEigenLayerCore is Script {
     using CoreDeploymentLib for *;
     using UpgradeableProxyLib for address;
 


### PR DESCRIPTION
This PR changes the contract name of the EigenLayer deployer from `DeployEigenlayerCore` to match the file's (`DeployEigenLayerCore`). Having the contract and file names differ in casing on a single letter could lead to errors when specifying it manually.