### PR TITLE
chore: fix typo in contract name

### DIFF
--- a/contracts/script/DeployEigenLayerCore.s.sol
+++ b/contracts/script/DeployEigenLayerCore.s.sol
@@ -10,7 +10,7 @@ import {IRewardsCoordinator} from "@eigenlayer/contracts/interfaces/IRewardsCoor
 
 import "forge-std/Test.sol";
 
-contract DeployEigenlayerCore is Script, Test {
+contract DeployEigenLayerCore is Script, Test {
     using CoreDeploymentLib for *;
     using UpgradeableProxyLib for address;
 


### PR DESCRIPTION
Change from #97 was undid recently (b8148c70093507d1a037f151e850c1771eb72e66).

Having the contract and file names differ in casing on a single letter is prone to errors.