### PR TITLE
fix: enable optimizer

### DIFF
--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -4,6 +4,7 @@ out = "out"
 libs = ["lib"]
 fs_permissions = [{ access = "read-write", path = "./" }]
 solc = "0.8.26"
+optimizer = true
 via-ir = true
 
 remappings = [

--- a/contracts/test/CoreDeploymentLib.t.sol
+++ b/contracts/test/CoreDeploymentLib.t.sol
@@ -19,10 +19,11 @@ contract CoreDeploymentLibTest is Test {
     }
 
     /// won't test specific functionality/values. Testing behavior of the library
-    function test_ReadConfig() view public {
+    function test_ReadConfig() public view {
         CoreDeploymentLib.readDeploymentConfigValues("test/mockData/config/core/", 1337);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_ReadConfig_Reverts() public {
         vm.expectRevert();
         /// Incorrect path
@@ -33,6 +34,7 @@ contract CoreDeploymentLibTest is Test {
         CoreDeploymentLib.readDeploymentJson("test/mockData/deployments/core/", 1337);
     }
 
+    /// forge-config: default.allow_internal_expect_revert = true
     function test_ReadDeployment_Reverts() public {
         vm.expectRevert();
         /// Incorrect path


### PR DESCRIPTION
Foundry recently changed the optimizer to be disabled by default. We need to enable it to have the old functionality back.

NOTE: failing tests are also due to recent foundry changes (see [here](https://book.getfoundry.sh/guides/v1.0-migration#expect-revert-cheatcode-disabled-on-internal-calls-by-default)). I fixed them by allowing `expectRevert` to catch internal reverts.