### PR TITLE
test: fix wrong path for obtaining contract addresses

### DIFF
--- a/operator/rust/crates/operator/src/test_utils.rs
+++ b/operator/rust/crates/operator/src/test_utils.rs
@@ -139,6 +139,7 @@ async fn register_operator() -> Result<()> {
 
     let delegation_manager_address =
         parse_delegation_manager_address("contracts/deployments/core/31337.json")?;
+    dbg!(&delegation_manager_address);
     let avs_directory_address: Address =
         parse_avs_directory_address("contracts/deployments/core/31337.json")?;
 


### PR DESCRIPTION
# WIP

There was a problem with the path used to obtain the addresses of some contracts. We need to use the absolute path instead of `contracts/deployments/core/31337.json` and `contracts/deployments/hello-world/31337.json`.