### PR TITLE
ci: add build rust ci

### DIFF
--- a/.github/workflows/ci_rust.yaml
+++ b/.github/workflows/ci_rust.yaml
@@ -1,4 +1,4 @@
-name: Rust CI
+name: Build Rust CI
 
 on:
   push:

--- a/.github/workflows/ci_rust.yaml
+++ b/.github/workflows/ci_rust.yaml
@@ -28,3 +28,11 @@ jobs:
       - name: Run cargo build
         run: |
           cargo build
+      
+      - name: Run cargo clippy
+        run: |
+          cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: Run cargo fmt
+        run: |
+          cargo fmt --all -- --check

--- a/.github/workflows/ci_rust.yaml
+++ b/.github/workflows/ci_rust.yaml
@@ -5,9 +5,6 @@ on:
     branches: ["master"]
   pull_request:
     branches: ["**"]
-    paths:
-      - "operator/rust/**"
-      - "Cargo.toml"
 
 env:
   RUST_VERSION: 1.79

--- a/.github/workflows/ci_rust.yaml
+++ b/.github/workflows/ci_rust.yaml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: ["**"]
     paths:
-      - "operator/rust"
+      - "operator/rust/**"
       - "Cargo.toml"
 
 env:

--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -1,0 +1,33 @@
+name: Rust CI
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["**"]
+    paths:
+      - "operator/rust"
+      - "Cargo.toml"
+
+env:
+  RUST_VERSION: 1.79
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Rustup toolchain install
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: ${{ env.RUST_VERSION }}
+
+      - name: Caching
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run cargo build
+        run: |
+          cargo build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rust.missing_debug_implementations = "warn"
 rust.missing_docs = "warn"
 rust.unreachable_pub = "warn"
 rust.unused_must_use = "deny"
-rust.rust_2018_idioms = "deny"
+rust_2018_idioms = { level = "deny", priority = -1 }
 rustdoc.all = "warn"
 
 
@@ -39,7 +39,3 @@ eigen-types = {git = "https://github.com/Layr-labs/eigensdk-rs", rev = "f3a9f32"
 eigen-utils = {git = "https://github.com/Layr-labs/eigensdk-rs", rev = "f3a9f32"}
 eigen-logging = {git = "https://github.com/Layr-labs/eigensdk-rs", rev = "f3a9f32"}
 eigen-testing-utils = {git = "https://github.com/Layr-labs/eigensdk-rs", rev = "f3a9f32"}
-
-
-
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rust.missing_debug_implementations = "warn"
 rust.missing_docs = "warn"
 rust.unreachable_pub = "warn"
 rust.unused_must_use = "deny"
-rust_2018_idioms = { level = "deny", priority = -1 }
+rust.rust_2018_idioms = { level = "deny", priority = -1 }
 rustdoc.all = "warn"
 
 


### PR DESCRIPTION
This PR adds a new CI workflow for Rust.
- The workflow checks the build, runs clippy, and verifies formatting with fmt.
- Updated `cargo.toml` to resolve dependency issues by setting the `rust_2018_idioms` priority to -1.

With this change, the CI (`cargo clippy --all-targets --all-features -- -D warnings`) will fail due to existing warnings in the codebase, which will be fixed in a future PR.