### PR TITLE
ci: add build TS CI

### DIFF
--- a/.github/workflows/ci_ts.yml
+++ b/.github/workflows/ci_ts.yml
@@ -1,0 +1,28 @@
+name: Build Typescript CI
+
+on:
+  push:
+    branches: ["master"]
+  pull_request:
+    branches: ["**"]
+
+env:
+  NODE_VERSION: 20
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Install packages
+        run: npm install
+
+      - name: Build project
+        run: npm run build

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ cp .env.example .env
 cp contracts/.env.example contracts/.env
 
 # Updates dependencies if necessary and builds the contracts 
-npm run build
+npm run build:forge
 
 # Deploy the EigenLayer contracts
 npm run deploy:core

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "create-payments-root": "cd contracts && forge script script/SetupPayments.s.sol --rpc-url http://localhost:8545 --broadcast -v --sender 0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
     "claim-payments": "cd contracts && forge script script/SetupPayments.s.sol --rpc-url http://localhost:8545 --broadcast --sig \"executeProcessClaim()\" -v --sender 0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
     "create-operator-directed-payments-root": "cd contracts && forge script script/SetupPayments.s.sol --rpc-url http://localhost:8545 --broadcast --sig \"runOperatorDirected()\" -v --sender 0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266",
-    "build": "cd contracts && forge build",
+    "build": "tsc",
+    "build:forge": "cd contracts && forge build",
     "extract:abis": "node utils/abis.js",
     "test": "NODE_OPTIONS=\"$NODE_OPTIONS --experimental-vm-modules\" npx jest"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "outDir": "./dist",
     "rootDir": "./",
     "strict": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
This PR adds a new CI workflow for TypeScript.

- Added a new CI flow.
- Added a new rule in `package.json`: `npm run build` builds the project and `npm run build:forge` builds the contracts.
- Updated the `README` with the new rule.
- Set `"skipLibCheck": true` in `tsconfig.json.`

I tried to install the dependencies of the external dependencies (`vitest` and `rollup`) as dev-dependencies, but there is a compatibility issue with the `module` and `moduleResolution` settings. It seems that the [easiest](https://github.com/rollup/rollup/issues/5199#issuecomment-2643123630) option is to use `"skipLibCheck": true` in `tsconfig.json,` which skips checking external libraries. Another option could be to change the `module` and `moduleResolution` settings, but I’m not sure if that’s something we want to do.

Errors:

```bash
➜  hello-world-avs git:(ci/build-ts) ✗ npm run build

> hello-world-avs@1.0.0 build
> tsc

node_modules/@viem/anvil/dist/types/proxy/createProxy.d.ts:6:32 - error TS2307: Cannot find module 'vitest' or its corresponding type declarations.

6 import type { Awaitable } from "vitest";
```

```bash
➜  hello-world-avs git:(ci/build-ts) ✗ npm run build

> hello-world-avs@1.0.0 build
> tsc

node_modules/vite/dist/node/index.d.ts:5:41 - error TS2307: Cannot find module 'rollup/parseAst' or its corresponding type declarations.
  There are types at '/Users/damiramirez/eigen/hello-world-avs/node_modules/rollup/dist/parseAst.d.ts', but this result could not be resolved under your current 'moduleResolution' setting. Consider updating to 'node16', 'nodenext', or 'bundler'.

5 export { parseAst, parseAstAsync } from 'rollup/parseAst';
                                          ~~~~~~~~~~~~~~~~~


Found 1 error in node_modules/vite/dist/node/index.d.ts:5
```