### PR TITLE
docs: improve slashing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ That's it. This simple flow highlights some of the core mechanics of how AVSs wo
 ### Slashing
 
 > [!WARNING]
-> This example does not use the new `operatorSets` workflow. Please refer to [ELIP-002](https://github.com/eigenfoundation/ELIPs/blob/main/ELIPs/ELIP-002.md) for more details. 
+> This example does not use the new operator-sets workflow. Please refer to [ELIP-002](https://github.com/eigenfoundation/ELIPs/blob/main/ELIPs/ELIP-002.md) for more details. 
 > For an example of the new workflow, check out [incredible-squaring-go](https://github.com/Layr-Labs/incredible-squaring-avs) or [incredible-squaring-rust](https://github.com/Layr-Labs/incredible-squaring-avs-rs).
 
 The example includes a simple slashing condition: "a task MUST be responded by enough operators before N blocks have passed since the task creation". You can modify the `OPERATOR_RESPONSE_PERCENTAGE` value in the `.env` file to adjust the chance of an operator responding to a task.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ That's it. This simple flow highlights some of the core mechanics of how AVSs wo
 
 ### Slashing
 
+> [!WARNING]
+> This example does not use the new `operatorSets` workflow. Please refer to [ELIP-002](https://github.com/eigenfoundation/ELIPs/blob/main/ELIPs/ELIP-002.md) for more details. 
+> For an example of the new workflow, check out [incredible-squaring-go](https://github.com/Layr-Labs/incredible-squaring-avs) or [incredible-squaring-rust](https://github.com/Layr-Labs/incredible-squaring-avs-rs).
+
 The example includes a simple slashing condition: "a task MUST be responded by enough operators before N blocks have passed since the task creation". You can modify the `OPERATOR_RESPONSE_PERCENTAGE` value in the `.env` file to adjust the chance of an operator responding to a task.
 In case this condition isn't satisfied by some operator, anyone can permissionlessly slash them via calling `HelloWorldServiceManager.slashOperator`.
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ That's it. This simple flow highlights some of the core mechanics of how AVSs wo
 The example includes a simple slashing condition: "a task MUST be responded by enough operators before N blocks have passed since the task creation". You can modify the `OPERATOR_RESPONSE_PERCENTAGE` value in the `.env` file to adjust the chance of an operator responding to a task.
 In case this condition isn't satisfied by some operator, anyone can permissionlessly slash them via calling `HelloWorldServiceManager.slashOperator`.
 
+For the [Rust example](#rust-operator-instructions), we have a `challenger` that listens for new tasks and checks whether the operators have responded. If not, `challenger` is authorized to slash the operator.
+
 # Local Devnet Deployment
 
 The following instructions explain how to manually deploy the AVS from scratch including EigenLayer and AVS specific contracts using Foundry (forge) to a local anvil chain, and start Typescript Operator application and tasks.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ That's it. This simple flow highlights some of the core mechanics of how AVSs wo
 
 > [!WARNING]
 > This example does not use the new operator-sets workflow. Please refer to [ELIP-002](https://github.com/eigenfoundation/ELIPs/blob/main/ELIPs/ELIP-002.md) for more details. 
-> For an example of the new workflow, check out [incredible-squaring-go](https://github.com/Layr-Labs/incredible-squaring-avs) or [incredible-squaring-rust](https://github.com/Layr-Labs/incredible-squaring-avs-rs).
+> For an example of the new workflow, check out the Incredible Squaring examples ([Go version here](https://github.com/Layr-Labs/incredible-squaring-avs), [Rust version here](https://github.com/Layr-Labs/incredible-squaring-avs-rs)).
 
 The example includes a simple slashing condition: "a task MUST be responded by enough operators before N blocks have passed since the task creation". You can modify the `OPERATOR_RESPONSE_PERCENTAGE` value in the `.env` file to adjust the chance of an operator responding to a task.
 In case this condition isn't satisfied by some operator, anyone can permissionlessly slash them via calling `HelloWorldServiceManager.slashOperator`.


### PR DESCRIPTION
This PR adds a warning explaining that this example does not use the new operatorSet workflow. It also explain that the Rust example includes a challenger with the permission to slash an operator who does not respond to a task in time.